### PR TITLE
Update tr.json

### DIFF
--- a/tr.json
+++ b/tr.json
@@ -14,7 +14,7 @@
   "If you did not create an account, no further action is required.": "Bir hesap oluşturmadıysanız, başka bir işlem yapmanız gerekmez.",
   "If you did not receive the email": "E-postayı almadıysanız",
   "If you did not request a password reset, no further action is required.": "Bir parola sıfırlama isteğinde bulunmadıysanız, başka bir işlem yapmanız gerekmez.",
-  "If you’re having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\" düğmesini tıklamakta sorun yaşıyorsanız, aşağıdaki linki kopyalayıp\ntarayıcınıza yapıştırın:",
+  "If you're having trouble clicking the \":actionText\" button, copy and paste the URL below\ninto your web browser:": "\":actionText\" düğmesini tıklamakta sorun yaşıyorsanız, aşağıdaki linki kopyalayıp\ntarayıcınıza yapıştırın:",
   "Login": "Giriş Yap",
   "Logout": "Çıkış Yap",
   "Name": "Ad",


### PR DESCRIPTION
Mail şablonu altında bulunan link açıklaması için
`'` *(Apostrophe / U+0027)* yerine `’` *(Right Single Quotation Mark / U+2019)* işaretinin kullanılması ve dil dosyasının çözülememesi sebebiyle oluşan hatanın revizesi